### PR TITLE
Fix recently added documents query to work with MySQL/MariaDB

### DIFF
--- a/mayan/apps/documents/views/document_views.py
+++ b/mayan/apps/documents/views/document_views.py
@@ -624,11 +624,10 @@ class RecentAccessDocumentListView(DocumentListView):
 
 class RecentAddedDocumentListView(DocumentListView):
     def get_document_queryset(self):
-        return Document.objects.filter(
-            pk__in=Document.objects.order_by('-date_added')[
-                :setting_recent_added_count.value
-            ].values('pk')
-        ).order_by('-date_added')
+        pks = [doc['pk'] for doc in
+            Document.objects.order_by('-date_added')[
+                :setting_recent_added_count.value].values('pk')]
+        return Document.objects.filter(pk__in=pks).order_by('-date_added')
 
     def get_extra_context(self):
         context = super(RecentAddedDocumentListView, self).get_extra_context()


### PR DESCRIPTION
Using MySQL/MariaDB opening the recently added documents page triggers error 1235 "This version of MariaDB doesn't yet support 'LIMIT & IN/ALL/ANY/SOME subquery'". I had a look into fixing this, and it's quite simple, see the attached PR.