### PR TITLE
Added a 'CSRF Origin' configuration example to .env file

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -54,6 +54,9 @@ MAYAN_TRAEFIK_RABBITMQ_ENABLE=false
 # Change if you use external services.
 MAYAN_DOCKER_WAIT="postgresql:5432 rabbitmq:5672 redis:6379"
 
+# To prevent CSRF Token mismatch errors when running behind a reverse proxy, you may add your HTTPS endpoint as a trusted origin. 
+# MAYAN_CSRF_TRUSTED_ORIGINS=['https://staging.mayan.cloud']
+
 
 #########################################################
 # These variables are passed to the running containers. #


### PR DESCRIPTION
What changed:
Added an example configuration for adding a Trusted CSRF Origin in the .env file.

Why this change:
New users may not be aware that this particular configuration is available to tweak and might struggle to fix CSRF token mismatch errors when they try to log in